### PR TITLE
Requirements conditional on platform_system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 asyncqt==0.8.0
 bleak==0.21.1
 numpy==1.25.2
-pyobjc-core==9.2
-pyobjc-framework-Cocoa==9.2
-pyobjc-framework-CoreBluetooth==9.2
-pyobjc-framework-libdispatch==9.2
+pyobjc-core==9.2; platform_system == 'Darwin'
+pyobjc-framework-Cocoa==9.2; platform_system == 'Darwin'
+pyobjc-framework-CoreBluetooth==9.2; platform_system == 'Darwin'
+pyobjc-framework-libdispatch==9.2; platform_system == 'Darwin'
 PySide6==6.5.2
 PySide6-Addons==6.5.2
 PySide6-Essentials==6.5.2


### PR DESCRIPTION
As far as I can tell the pyobjc dependencies aren't needed on Linux/Windows. This makes them conditional on the platform using Python environment markers (https://peps.python.org/pep-0508/; `platform_system` is equivalent to `python -c "import platform;print(platform.system())`.

I can't test if this works as expected on macOS combined with the version pinning, but I believe it should.

Fixes #3.