### PR TITLE
Switch from `asyncqt` to `qasync`

### DIFF
--- a/EBYT.py
+++ b/EBYT.py
@@ -1,12 +1,12 @@
 
 import os
-os.environ['QT_API'] = 'PySide6' # For asyncqt to know which binding is being used
+os.environ['QT_API'] = 'PySide6' # For qasync to know which binding is being used
 os.environ['QT_LOGGING_RULES'] = 'qt.pointer.dispatch=false' # Disable pointer logging
 
 import sys
 import asyncio
 from PySide6.QtWidgets import QApplication
-from asyncqt import QEventLoop
+from qasync import QEventLoop
 from View import View
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncqt==0.8.0
 bleak==0.21.1
 numpy==1.25.2
 pyobjc-core==9.2
@@ -8,6 +7,7 @@ pyobjc-framework-libdispatch==9.2
 PySide6==6.5.2
 PySide6-Addons==6.5.2
 PySide6-Essentials==6.5.2
+qasync==0.24.0
 scipy==1.11.2
 shiboken6==6.5.2
 typing_extensions==4.7.1


### PR DESCRIPTION
When running the app I got infinite messages like this in the terminal:

> TypeError: unhashable type: 'PySide6.QtCore.QSocketDescriptor'
> Traceback (most recent call last):
>   File "/home/arjan/.virtualenvs/every-breath-you-take/lib/python3.11/site-packages/asyncqt/_unix.py", line 124, in __on_read_activated
>     key = self._key_from_fd(fd)
>           ^^^^^^^^^^^^^^^^^^^^^
>   File "/home/arjan/.virtualenvs/every-breath-you-take/lib/python3.11/site-packages/asyncqt/_unix.py", line 188, in _key_from_fd
>     return self._fd_to_key[fd]
>            ~~~~~~~~~~~~~~~^^^^
> TypeError: unhashable type: 'PySide6.QtCore.QSocketDescriptor'
> Traceback (most recent call last):
>   File "/home/arjan/Software/kbre93/every-breath-you-take/EBYT.py", line 23, in <module>
>     loop.run_until_complete(plot.main())
>   File "/home/arjan/.virtualenvs/every-breath-you-take/lib/python3.11/site-packages/asyncqt/__init__.py", line 306, in run_until_complete
>     raise RuntimeError('Event loop stopped before Future completed.')
> RuntimeError: Event loop stopped before Future completed.

I think this is because `asyncqt` is meant for PySide2, while PySide6 seems to require the newer fork `qasync`. Switching over to `qasync` indeed fixes this.